### PR TITLE
Add anchor points for references in the glossary (terms_and_definitions.adoc)

### DIFF
--- a/content/terms_and_definitions.adoc
+++ b/content/terms_and_definitions.adoc
@@ -1,0 +1,117 @@
+[#top-terms_and_definitions-terms_and_definitions]
+= Terms and definitions
+
+ifndef::include-only-once[]
+:root-path: ../
+include::{root-path}_config.adoc[]
+endif::[]
+
+3D asset::
+The combination of an object's 3D geometry, assigned material properties, and
+specific metadata.
+
+3D model::
+A mathematical coordinate-based representation of an object's geometrical
+surface. Material properties used for rendering purposes can be part of the 3D model. This excludes physical material properties. For a combination of 3D
+geometry and physical material properties, see 3D asset.
+
+3D environment::
+A 3D representation of a simulated sensor's surroundings. It can consist of
+multiple 3D assets.
+
+Co-simulation::
+Simulation of multiple independent models connected with interfaces. A
+co-simulation platform handles the timing, synchronization, and data transfer between the
+individual models.
+
+Ground truth::
+Defines true static and dynamic states of objects. The true states are either
+determined by the content creator or defined by an omniscient observer, for
+example, a simulation platform.
+
+Machine perception::
+The ability of systems to interpret sensory data and to reliably detect objects
+and other road users relevant to the operation of automated driving. The data is
+used to generate situational awareness of the vehicle environment.
++
+Source: Klaus Dietmayer, Predicting of Machine Perception for Automated Driving, 2016
+
+Material::
+A collection of material properties belonging to one entity.
+
+Material assignment::
+A mapping of material IDs to meshes of 3D models, or pixels of textures mapped to these meshes. The material ID is a unique
+pointer to a set of material properties in separate material files.
+
+Material classification::
+Standardized classification scheme that sorts materials into classes and groups
+of classes, for example, based on their physical properties.
+
+Material parameter file::
+A file in JSON format containing defined material properties according to the
+OpenMATERIAL standard.
+
+Material property::
+Denotes a physical, chemical, or geometric property of a material.
+
+Multispectral/hyperspectral material::
+Material with wavelength-specific properties that are defined for multiple spectra. 
++
+Multispectral material shows up in imagery as 3-10 wider bands.
++
+Hyperspectral material shows hundreds of narrow bands. 
+
+Object::
+A tangible thing with defined 3D boundaries and discrete meshes. An object ID
+can be assigned.
+
+Object part::
+A segment of an object that has distinct characteristics, for example, material,
+shape, or function.
++
+Example: A car door differs from the rest of the vehicle due to its function
+to open and close.
+
+Object type::
+Class of objects with the same set of properties. Each instance of the class is
+described by the same properties, but has individual property values.
+
+Physical property::
+Denotes a characteristic of an object or material that can be measured.
+Examples: permittivity, density, index of refraction.
+
+Post rendering effect::
+Visual modification applied to graphics after initial rendering, enhancing
+appearance or realism without impairing performance.
+
+Scenario::
+A description of the behavior or temporal evolution of physical objects and
+environmental conditions on the driving infrastructure over an interval of time,
+including the movement of traffic participants or the change of environmental
+conditions.
++
+Source: ASAM OpenSCENARIO v1.3.0 standard, 2024
+
+Signal energy propagation::
+The act of a signal traveling through the environment and potentially
+interacting with objects and particles.
++
+Source: Linnhoff et al., Towards Serious Perception Sensor Simulation for Safety Validation of Automated Driving - A Collaborative Method to Specify Sensor Models, 2021
+
+Simulation platform::
+Application that orchestrates and runs the simulations. It can be either an
+all-in-one solution including the generation of the 3D environment or a
+co-simulation platform orchestrating a co-simulation of multiple sensor models, vehicle dynamics models, and so on.
+
+Surface normal::
+A vector that is perpendicular to a given object, surface, or geometrical
+primitive. It can be used to determine the face direction for 2D and
+3D rendering.
+
+Validation::
+A method for evaluating a simulation model's performance and accuracy by
+comparing simulated data to measured data and quantifying the differences.
+
+Vertex normal::
+A directional vector that is associated with a vertex. It represents the
+normalized average of the surrounding surface normals.

--- a/content/terms_and_definitions.adoc
+++ b/content/terms_and_definitions.adoc
@@ -6,85 +6,85 @@ ifndef::include-only-once[]
 include::{root-path}_config.adoc[]
 endif::[]
 
-3D asset::
+[[sec-3D-asset]] 3D asset::
 The combination of an object's 3D geometry, assigned material properties, and
 specific metadata.
 
-3D model::
+[[sec-3D-model]] 3D model::
 A mathematical coordinate-based representation of an object's geometrical
 surface. Material properties used for rendering purposes can be part of the 3D model. This excludes physical material properties. For a combination of 3D
 geometry and physical material properties, see 3D asset.
 
-3D environment::
+[[sec-3D-environment]] 3D environment::
 A 3D representation of a simulated sensor's surroundings. It can consist of
 multiple 3D assets.
 
-Co-simulation::
+[[sec-Co-simulation]] Co-simulation::
 Simulation of multiple independent models connected with interfaces. A
 co-simulation platform handles the timing, synchronization, and data transfer between the
 individual models.
 
-Ground truth::
+[[sec-Ground-truth]] Ground truth::
 Defines true static and dynamic states of objects. The true states are either
 determined by the content creator or defined by an omniscient observer, for
 example, a simulation platform.
 
-Machine perception::
+[[sec-Machine-perception]] Machine perception::
 The ability of systems to interpret sensory data and to reliably detect objects
 and other road users relevant to the operation of automated driving. The data is
 used to generate situational awareness of the vehicle environment.
 +
 Source: Klaus Dietmayer, Predicting of Machine Perception for Automated Driving, 2016
 
-Material::
+[[sec-Material]] Material::
 A collection of material properties belonging to one entity.
 
-Material assignment::
+[[sec-Material-assignment]] Material assignment::
 A mapping of material IDs to meshes of 3D models, or pixels of textures mapped to these meshes. The material ID is a unique
 pointer to a set of material properties in separate material files.
 
-Material classification::
+[[sec-Material-classification]] Material classification::
 Standardized classification scheme that sorts materials into classes and groups
 of classes, for example, based on their physical properties.
 
-Material parameter file::
+[[sec-Material-parameter-file]] Material parameter file::
 A file in JSON format containing defined material properties according to the
 OpenMATERIAL standard.
 
-Material property::
+[[sec-Material-property]] Material property::
 Denotes a physical, chemical, or geometric property of a material.
 
-Multispectral/hyperspectral material::
+[[sec-Multispectral_hyperspectral-material]] Multispectral/hyperspectral material::
 Material with wavelength-specific properties that are defined for multiple spectra. 
 +
 Multispectral material shows up in imagery as 3-10 wider bands.
 +
 Hyperspectral material shows hundreds of narrow bands. 
 
-Object::
+[[sec-Object]] Object::
 A tangible thing with defined 3D boundaries and discrete meshes. An object ID
 can be assigned.
 
-Object part::
+[[sec-Object-part]] Object part::
 A segment of an object that has distinct characteristics, for example, material,
 shape, or function.
 +
 Example: A car door differs from the rest of the vehicle due to its function
 to open and close.
 
-Object type::
+[[sec-Object-type]] Object type::
 Class of objects with the same set of properties. Each instance of the class is
 described by the same properties, but has individual property values.
 
-Physical property::
+[[sec-Physical-property]] Physical property::
 Denotes a characteristic of an object or material that can be measured.
 Examples: permittivity, density, index of refraction.
 
-Post rendering effect::
+[[sec-Post-rendering-effect]] Post rendering effect::
 Visual modification applied to graphics after initial rendering, enhancing
 appearance or realism without impairing performance.
 
-Scenario::
+[[sec-Scenario]] Scenario::
 A description of the behavior or temporal evolution of physical objects and
 environmental conditions on the driving infrastructure over an interval of time,
 including the movement of traffic participants or the change of environmental
@@ -92,26 +92,26 @@ conditions.
 +
 Source: ASAM OpenSCENARIO v1.3.0 standard, 2024
 
-Signal energy propagation::
+[[sec-Signal-energy-propagation]] Signal energy propagation::
 The act of a signal traveling through the environment and potentially
 interacting with objects and particles.
 +
 Source: Linnhoff et al., Towards Serious Perception Sensor Simulation for Safety Validation of Automated Driving - A Collaborative Method to Specify Sensor Models, 2021
 
-Simulation platform::
+[[sec-Simulation-platform]] Simulation platform::
 Application that orchestrates and runs the simulations. It can be either an
 all-in-one solution including the generation of the 3D environment or a
 co-simulation platform orchestrating a co-simulation of multiple sensor models, vehicle dynamics models, and so on.
 
-Surface normal::
+[[sec-Surface-normal]] Surface normal::
 A vector that is perpendicular to a given object, surface, or geometrical
 primitive. It can be used to determine the face direction for 2D and
 3D rendering.
 
-Validation::
+[[sec-Validation]] Validation::
 A method for evaluating a simulation model's performance and accuracy by
 comparing simulated data to measured data and quantifying the differences.
 
-Vertex normal::
+[[sec-Vertex-normal]] Vertex normal::
 A directional vector that is associated with a vertex. It represents the
 normalized average of the surrounding surface normals.


### PR DESCRIPTION
## Describe your changes

add anchor points so that the glossary terms can be referenced within the standard

