### PR TITLE
Fix the table of content for geometry and material chapter

### DIFF
--- a/.antora/modules/specification/nav_openmaterial.adoc
+++ b/.antora/modules/specification/nav_openmaterial.adoc
@@ -6,7 +6,17 @@
 * xref:general_docs/backward_compatibility.adoc[]
 * xref:terms_and_definitions/terms_and_definitions.adoc[]
 * xref:use_cases/use_cases.adoc[]
-* xref:geometry/general-structure-index.adoc[]
-* xref:material/general-structure-index.adoc[]
-* great
+* Geometry
+* xref:Introduction.adoc[]
+** xref:General.adoc[]
+** xref:Object-Geometry_classes_and_segmentation.adoc[]
+** xref:File_format_support.adoc[]
+** xref:Metadata.adoc[]
+** xref:Performance.adoc[]
+* Material
+** xref:Introduction.adoc[]
+** xref:Fileformat.adoc[]
+** xref:Metadata.adoc[]
+** xref:Material-parameters.adoc[]
+
 

--- a/.antora/modules/specification/nav_openmaterial.adoc
+++ b/.antora/modules/specification/nav_openmaterial.adoc
@@ -8,6 +8,6 @@
 * xref:use_cases/use_cases.adoc[]
 * Geometry
 ** xref:geometry/general-structure-index.adoc[]
-* Material
+* Materials
 ** xref:material/general-structure-index.adoc[]
 

--- a/.antora/modules/specification/nav_openmaterial.adoc
+++ b/.antora/modules/specification/nav_openmaterial.adoc
@@ -6,8 +6,7 @@
 * xref:general_docs/backward_compatibility.adoc[]
 * xref:terms_and_definitions/terms_and_definitions.adoc[]
 * xref:use_cases/use_cases.adoc[]
-* Geometry
-** xref:geometry/general-structure-index.adoc[]
-* Materials
-** xref:material/general-structure-index.adoc[]
+* xref:geometry/general-structure-index.adoc[]
+* xref:material/general-structure-index.adoc[]
+* great
 

--- a/.antora/modules/specification/nav_openmaterial.adoc
+++ b/.antora/modules/specification/nav_openmaterial.adoc
@@ -7,16 +7,16 @@
 * xref:terms_and_definitions/terms_and_definitions.adoc[]
 * xref:use_cases/use_cases.adoc[]
 * Geometry
-* xref:Introduction.adoc[]
-** xref:General.adoc[]
-** xref:Object-Geometry_classes_and_segmentation.adoc[]
-** xref:File_format_support.adoc[]
-** xref:Metadata.adoc[]
-** xref:Performance.adoc[]
+** xref:geometry/Introduction.adoc[]
+** xref:geometry/General.adoc[]
+** xref:geometry/Object-Geometry_classes_and_segmentation.adoc[]
+** xref:geometry/File_format_support.adoc[]
+** xref:geometry/Metadata.adoc[]
+** xref:geometry/Performance.adoc[]
 * Material
-** xref:Introduction.adoc[]
-** xref:Fileformat.adoc[]
-** xref:Metadata.adoc[]
-** xref:Material-parameters.adoc[]
+** xref:material/Introduction.adoc[]
+** xref:material/Fileformat.adoc[]
+** xref:material/Metadata.adoc[]
+** xref:material/Material-parameters.adoc[]
 
 


### PR DESCRIPTION
Update the antora nav file so that all subheadings are now in correct order