### PR TITLE
Trigger full Antora build 

### DIFF
--- a/.github/workflows/antora-build-full.yml
+++ b/.github/workflows/antora-build-full.yml
@@ -1,0 +1,29 @@
+name: Full Antora documentation build
+# Based on OSI configuration https://github.com/OpenSimulationInterface/osi-documentation/blob/master/.github/workflows/antora-build.yml
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
+ 
+jobs:
+  trigger_antora:
+    name: Trigger OpenMATERIAL Antora generator
+
+    runs-on: Ubuntu-latest
+
+    env:
+     DISPATCH_KEY: ${{ secrets.ANTORA_DISPATCH }}
+
+    steps:
+    - name: Trigger Antora generator
+      if: ${{ env.DISPATCH_KEY != '' }}
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        token: ${{ secrets.ANTORA_DISPATCH }}
+        event-type: antora-build-trigger
+        repository:  asam-ev/openmaterial-antora-generator
+        client-payload: '{"src": "${{ github.repository }}", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "head_ref": "${{ github.head_ref }}"}'
+ 


### PR DESCRIPTION
## Describe your changes

Add a new GitHub workflow that triggers the Antora generator at https://github.com/asam-ev/openmaterial-antora-generator. This is based on the OSI configuration https://github.com/OpenSimulationInterface/osi-documentation/blob/master/.github/workflows/antora-build.yml

## Prerequisites
There were are number of settings required on the organization level of asam-ev:

- Allow remote access to repos with personal access token (PAT).
- Create a PAT for dispatching an event to a remote repository (https://github.com/peter-evans/repository-dispatch?tab=readme-ov-file#token)
- Create and configure a GitHub secret to be able to use the PAT in a workflow (https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow)

These prerequisites were done together with @AsamDiegoSanchez. 

## Checklist before requesting a review

- [x] I have performed a self-review of my code/documentation.
- [x] My changes generate no new warnings during the documentation generation.