### PR TITLE
184 metadata multiple times in documentation generated from schema

### DIFF
--- a/scripts/json2asciidoc.py
+++ b/scripts/json2asciidoc.py
@@ -91,8 +91,8 @@ def generate_asciidoc_properties(properties, required_fields, level=2):
         
         # Add pattern inline and handle escaping of backslashes and curly braces
         if "pattern" in prop_data:
-            #pattern = escape_special_chars(prop_data['pattern'])
-            asciidoc_content += f"\n*Pattern:* `{prop_data['pattern']}`\n"
+            pattern = escape_special_chars(prop_data['pattern'])
+            asciidoc_content += f"\n*Pattern:* `+{pattern}+`\n"
         
         # Add a new line before required status
         if prop_name in required_fields:

--- a/scripts/json2asciidoc.py
+++ b/scripts/json2asciidoc.py
@@ -91,8 +91,8 @@ def generate_asciidoc_properties(properties, required_fields, level=2):
         
         # Add pattern inline and handle escaping of backslashes and curly braces
         if "pattern" in prop_data:
-            pattern = escape_special_chars(prop_data['pattern'])
-            asciidoc_content += f"\n*Pattern:* `{pattern}`\n"
+            #pattern = escape_special_chars(prop_data['pattern'])
+            asciidoc_content += f"\n*Pattern:* `{prop_data['pattern']}`\n"
         
         # Add a new line before required status
         if prop_name in required_fields:

--- a/scripts/json2asciidoc.py
+++ b/scripts/json2asciidoc.py
@@ -30,7 +30,7 @@ def escape_special_chars(pattern):
         str: The escaped pattern string.
     """
     pattern = pattern.replace("\\", "\\\\")  # Escape backslashes
-    pattern = pattern.replace("{", "\\{").replace("}", "\\}")  # Escape curly braces
+    #pattern = pattern.replace("{", "\\{").replace("}", "\\}")  # Escape curly braces
     return pattern
 
 

--- a/scripts/json2asciidoc.py
+++ b/scripts/json2asciidoc.py
@@ -30,7 +30,6 @@ def escape_special_chars(pattern):
         str: The escaped pattern string.
     """
     pattern = pattern.replace("\\", "\\\\")  # Escape backslashes
-    #pattern = pattern.replace("{", "\\{").replace("}", "\\}")  # Escape curly braces
     return pattern
 
 


### PR DESCRIPTION
## Describe your changes

Fix bugs in generating the documentation from the schemas.
I tested it on my fork:
https://clemenslinnhoff.github.io/OpenMATERIAL/asamopenmaterial/latest/specification/geometry/asset-schema.html

## Issue ticket number and link

Fixes #184 

## Checklist before requesting a review

- [x] I have performed a self-review of my code/documentation.
- [x] My changes generate no new warnings during the documentation generation.