### PR TITLE
Divided the measurement data file into two files.

### DIFF
--- a/schemas/material_brdf_schema.json
+++ b/schemas/material_brdf_schema.json
@@ -70,7 +70,7 @@
       "properties": {
         "typicalSensor": {
           "type": "string",
-          "description": "Typical sensor technology this BRDF table is used for, e.g., radar, lidar, camera."
+          "description": "Typical sensor technology this BRDF table is used for, e.g., camera, lidar..."
         },
         "wavelengthRange": {
           "type": "array",
@@ -80,11 +80,6 @@
             },
            "minItems": 2,
            "maxItems": 2
-        },
-        "amplitudeUnit": {
-          "type": "string",
-          "description": "The unit of amplitude, either \"1/sr\" or \"linear\"",
-          "enum": ["1/sr", "linear"]
         },
         "lookupTable": {
           "type": "array",
@@ -106,30 +101,21 @@
               },
               {
                 "type": ["number", "null"],
-                "description": "Polarized plane angle in rad. This is the angle between the plane containing the incident, exit, and normal vector, and the plane of polarization."
-              },
-              {
-                "type": ["number", "null"],
                 "description": "Wavelength in meters."
               },
               {
                 "type": ["number", "null"],
-                "description": "Amplitude within the linearly polarized plane."
-              },
-              {
-                "type": ["number", "null"],
-                "description": "Phase within the linearly polarized plane. If the phase is not taken into account, it is null."
+                "description": "Amplitude BRDF in 1/sr."
               }
             ],
-            "minItems": 7,
-            "maxItems": 7
+            "minItems": 5,
+            "maxItems": 5
           }
         }
       },
       "required": [
         "typicalSensor",
         "wavelengthRange",
-        "amplitudeUnit",
         "lookupTable"
       ]
     }

--- a/schemas/material_radar_reflect_schema.json
+++ b/schemas/material_radar_reflect_schema.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "description": "Metadata about the material.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the material."
+        },
+        "extensions" : {},
+        "extras" : {},
+        "description": {
+          "type": "string",
+          "description": "Short description of the material in 2 - 3 sentences."
+        },
+        "uuid": {
+          "type": "string",
+          "description": "Universally unique identifier for the material.",
+          "pattern": "^[a-f0-9]{32}$"
+        },
+        "materialVersion": {
+          "type": "string",
+          "description": "Version of the material.",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "creationDate": {
+          "type": "string",
+          "description": "Creation date of the material in the format YYYYMMDDTHHMMSSZ.",
+          "pattern": "^\\d{8}T\\d{6}Z$"
+        },
+        "openMaterialVersion": {
+          "type": "string",
+          "description": "Version of OpenMATERIAL.",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "copyright": {
+          "type": "string",
+          "description": "Copyright information with year and company."
+        },
+        "license": {
+          "type": "string",
+          "description": "License information. For common open source licenses, provide an SPDX identifier. For other types of licenses, provide an URL to a webpage with the license or the filename of a separately provided license file."
+        },
+        "author": {
+          "type": "string",
+          "description": "Name or email address of the author of this material. In case of multiple authors, use comma-separation. The author can also be a company name."
+        },
+        "source": {
+          "type": "string",
+          "description": "Source of the brdf data."
+        }
+      },
+      "required": [
+        "name",
+        "description",
+        "uuid",
+        "materialVersion",
+        "creationDate",
+        "openMaterialVersion",
+        "copyright",
+        "license",
+        "author",
+        "source"
+      ]
+    },
+    "radarReflectance": { 
+      "type": "object",
+      "description": "General information about the lookup table for Radar.",
+      "properties": {
+        "wavelengthRange": {
+          "type": "array",
+          "description": "Wavelength range covered by the lookup table. The first item is the minimum wavelength in meters and the second item is the maximum wavelength in meters.",
+          "items": {
+              "type": "number"
+            },
+           "minItems": 2,
+           "maxItems": 2
+        },
+        "lookupTable": {
+          "type": "array",
+          "description": "Array of Reflectance values, with each item representing a different property. The array SHALL be sorted based on the columns starting with the first.",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "type": ["number", "null"],
+                "description": "Incident elevation angle in rad."
+              },
+              {
+                "type": ["number", "null"],
+                "description": "Exit elevation angle in rad."
+              },
+              {
+                "type": ["number", "null"],
+                "description": "Exit azimuth angle in rad (for reflectance with incident and exit vectors on the same plane as the normal, exit azimuth angle is 0.)"
+              },
+              {
+                "type": ["number", "null"],
+                "description": "Polarized plane angle in rad. This is the angle between the plane containing the incident, exit, and normal vector, and the plane of polarization."
+              },
+              {
+                "type": ["number", "null"],
+                "description": "Wavelength in meters."
+              },
+              {
+                "type": ["number", "null"],
+                "description": "Amplitude within the linearly polarized plane."
+              },
+              {
+                "type": ["number", "null"],
+                "description": "Phase within the linearly polarized plane. If the phase is not taken into account, it is null."
+              }
+            ],
+            "minItems": 7,
+            "maxItems": 7
+          }
+        }
+      },
+      "required": [
+        "wavelengthRange",
+        "lookupTable"
+      ]
+    }
+  },
+  "required": [
+    "metadata",
+    "radarReflectance"
+  ]
+}


### PR DESCRIPTION
## Describe your changes

As a result of the discussion in issue #167, divided the measurement data file into two files, one for the camera and LiDAR and the other for the radar.

Depending on the file division, unnecessary information such as the description of the amplitude unit has been deleted.

## Issue ticket number and link

Related issue is   #167.
