### PR TITLE
Fix Chapter Drop-Down for Material and Geometry

### DIFF
--- a/content/nav-openmaterial.adoc
+++ b/content/nav-openmaterial.adoc
@@ -14,7 +14,7 @@
 * xref:general-docs/backward-compatibility.adoc[]
 * xref:terms-and-definitions/terms-and-definitions.adoc[]
 * xref:use-cases/use-cases.adoc[]
-* xref:geometry/geometry-index.adoc[]
+* 7 Geometry
 ** xref:geometry/introduction.adoc[]
 ** xref:geometry/general.adoc[]
 ** xref:geometry/object-classes.adoc[]
@@ -25,7 +25,7 @@
 ** xref:geometry/asset-schema.adoc[]
 ** xref:geometry/mapping-schema.adoc[]
 * xref:material/material-index.adoc[]
-** xref:material/introduction.adoc[]
+* 8 Material
 ** xref:material/material-schema.adoc[]
 ** xref:material/material-emp-schema.adoc[]
 ** xref:material/material-optical-schema.adoc[]


### PR DESCRIPTION
## Describe your changes

Replace "index" adoc files for geometry and material by hard coded chapter name in the nav file. In this way, the names "Geometry" and "Material" only shows up in the ToC.

## Issue ticket number and link

Fixes #258

