### PR TITLE
Add naming conventions to index; small editorial changes

### DIFF
--- a/content/geometry/object-environment/environment-index.adoc
+++ b/content/geometry/object-environment/environment-index.adoc
@@ -1,5 +1,6 @@
 = Environment structure
 
 include::environment-general.adoc[leveloffset=+1]
+include::environment-naming-convention.adoc[leveloffset=+1]
 include::environment-structure.adoc[leveloffset=+1]
 

--- a/content/geometry/object-environment/environment-naming-convention.adoc
+++ b/content/geometry/object-environment/environment-naming-convention.adoc
@@ -1,0 +1,7 @@
+= Naming convention
+
+Every object has a unique name and represents a part of the environment.
+All included meshes are part of a group to indicate which kind of object type it represents.
+All meshes should be named meaningful.
+
+If needed, the user is free to add more groups and new keywords, which are not part of the standard, for himself.

--- a/content/geometry/object-human/human-index.adoc
+++ b/content/geometry/object-human/human-index.adoc
@@ -1,4 +1,5 @@
 = Human structure
 
 include::human-general.adoc[leveloffset=+1]
+include::human-naming-convention.adoc[leveloffset=+1]
 include::human-structure.adoc[leveloffset=+1]

--- a/content/geometry/object-human/human-naming-convention.adoc
+++ b/content/geometry/object-human/human-naming-convention.adoc
@@ -1,6 +1,8 @@
-=== Naming convention
+= Naming convention
 
-Every bone has a unique name and represents a part of the human body. The left and right side of the armature are indicated with the keywords "Left" and "Right" as a postfix.
-All included meshes use a keyword as a prefix to indicate which kind of asset it represents. They shall be named meaningful.
+Every bone has a unique name and represents a part of the human body.
+The left and right side of the armature are indicated with the keywords "Left" and "Right" as a suffix.
+All included meshes use a keyword as a prefix to indicate which kind of object it represents.
+They shall be named meaningful.
 
 If needed, the user is free to add more prefixes or bones, which are not part of the standard, for himself.

--- a/content/geometry/object-road-network/environment-naming-convention.adoc
+++ b/content/geometry/object-road-network/environment-naming-convention.adoc
@@ -1,8 +1,0 @@
-=== Naming convention
-
-Every asset has a unique name and represents a part of the environment. All included meshes are part of a group to indicate which kind of asset type it represents.
-All meshes should be named meaningful.
-
-If needed, the user is free to add more groups and new keywords, which are not part of the standard, for himself.
-
-|===

--- a/content/geometry/object-vehicle/vehicle-index.adoc
+++ b/content/geometry/object-vehicle/vehicle-index.adoc
@@ -1,4 +1,5 @@
 = Vehicle structure
 
 include::vehicle-general.adoc[leveloffset=+1]
+include::vehicle-naming-convention.adoc[leveloffset=+1]
 include::vehicle-structure.adoc[leveloffset=+1]

--- a/content/geometry/object-vehicle/vehicle-naming-convention.adoc
+++ b/content/geometry/object-vehicle/vehicle-naming-convention.adoc
@@ -1,11 +1,13 @@
-=== Naming convention
+= Naming convention
 
-Every mesh has a unique name and represents a part of the vehicle. The different vehicle components can be identified by the keywords.
-All included meshes use one or more keywords to indicate which kind of asset it represents and where it is located.
+Every mesh has a unique name and represents a part of the vehicle.
+The different vehicle components can be identified by the keywords.
+All included meshes use one or more keywords to indicate which kind of object it represents and where it is located.
 Count the axle index from front to rear starting with 0 (according to the https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/gen/structosi3_1_1MovingObject_1_1VehicleAttributes_1_1WheelData.html#a094de989f5a2aab080f9a65f0feb3867[ASAM OSI definition]).
 Count the wheel index per axle from right to left (in positive y-direction and according to the https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/gen/structosi3_1_1MovingObject_1_1VehicleAttributes_1_1WheelData.html#a094de989f5a2aab080f9a65f0feb3867[ASAM OSI definition]).
 Count the door index per side from front to rear and right to left (in positive y-direction).
-Count the seat index per level from first level front to rear, and right to left, to the next level from right to left and front to rear. Note: A rear bench with 3 seats will be consideres as 3 seats, because 3 passengers could take a seat on it.
+Count the seat index per level from first level front to rear, and right to left, to the next level from right to left and front to rear.
+Note: A rear bench with 3 seats is considered as 3 seats, because 3 passengers could take a seat on it.
 
-If needed, the user is free to add more groups and new keywords, which are not part of the standard, for themself.
+If needed, the user is free to add more groups and new keywords, which are not part of the standard, for himself.
 


### PR DESCRIPTION
## Describe your changes

The object class-specific naming conventions somehow got lost in the indexing. I added them back to the index and did some minor editorial changes.

Now the sections show up in the documentation:
![image](https://github.com/user-attachments/assets/04fece2c-c904-42a0-9214-3c7dbfd6fe21)


## Issue ticket number and link
Fixes #307 

## Checklist before requesting a review

- [x] I have performed a self-review of my code/documentation.
- [x] My changes generate no new warnings during the documentation generation.