### PR TITLE
462 Remove type requirement for customProperties

### DIFF
--- a/schemas/asset_schema.json
+++ b/schemas/asset_schema.json
@@ -345,10 +345,7 @@
         },
         "customProperties": {
             "type": "object",
-            "description": "Non-standardized asset properties for custom tools or tool chains.",
-            "additionalProperties": {
-                "type": "string"
-            }
+            "description": "Non-standardized asset properties for custom tools or tool chains."
         }
     },
     "required": [

--- a/schemas/material_schema.json
+++ b/schemas/material_schema.json
@@ -216,10 +216,7 @@
                 },
                 "customProperties": {
                     "type": "object",
-                    "description": "Non-standardized material properties for custom tools or tool chains.",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                    "description": "Non-standardized material properties for custom tools or tool chains."
                 }
             }
         }


### PR DESCRIPTION
## Describe your changes

Remove the requirement that all customProperties entries must be of type string.

## Issue ticket number and link https://github.com/asam-ev/OpenMATERIAL-3D/issues/462

## Checklist before requesting a review

- [x] I have performed a self-review of my code/documentation.
- [x] My changes generate no new warnings during the documentation generation.