### PR TITLE
Add externalAssetReferences to schema and documentation 2 #118

### DIFF
--- a/content/07_geometry/general.adoc
+++ b/content/07_geometry/general.adoc
@@ -153,6 +153,22 @@ The following is an example of a _3D model_ file in glTF format with an accompan
 * `my-model.gltf`
 * `my-model.xoma`
 
+== Asset Type
+In the current specification of {THIS_STANDARD}, assets of type 'object' and 'scene' can be specified.
+ Since the concept of 'scene' has been replaced by the following concept of referencing external assets, it can be understood as deprecated.
+
+== References to external assets
+To accommodate use cases in which 3D objects are not built from single assets but from (variable) compositions of assets
+ (e.g., vehicles with roof racks and bicycles, environments built up by separate layers or enhanced with additional objects),
+  {THIS_STANDARD} allows external assets to be referenced in the _3D asset_ file.
+  
+To do this, the _3D asset_ files of external assets must be associated with a node of an overarching asset in its _3D asset_ file.
+ This node acts as parent to the external assets and determines their spatial placement and orientation.
+ The mapping is implemented as a list of key-value pairs of parent nodes and references to _3D asset_ files.
+  
+Example:
+A Grp_Wheel_Steering_Rotating_<axle_idx>_<wheel_idx> node in a vehicle asset could be a parent node for interchangeable car wheels, which are individually referenced from external assets.
+
 == Requirements
 
 * The geometry of the object shall be in real-word scale, using meters as the unit for measurement distances.

--- a/schemas/asset_schema.json
+++ b/schemas/asset_schema.json
@@ -109,7 +109,7 @@
                 },
                 "assetType": {
                     "type": "string",
-                    "description": "Specifies whether the asset represents an individual object ('object') or a collection of objects ('scene').",
+                    "description": "Specifies whether the asset represents an individual object ('object') or a collection of objects ('scene'). With the introduction of a concept for referencing external assets, 'scene' is deprecated.",
                     "enum": [
                         "object",
                         "scene"
@@ -307,7 +307,6 @@
                 "copyrights",
                 "license",
                 "authors",
-                "assetType",
                 "objectClass",
                 "animated",
                 "pbrMaterialWorkflow",
@@ -346,20 +345,19 @@
             "type": "array",
             "description": "Optional array containing references to external 3D assets. It links parenting nodes in the 3D model file to external ASAM OpenMATERIAL 3D asset files (.xoma).",
             "items": {
-                "type": "array",
-                "items": [
-                    {
+                "type": "object",
+				"required": ["reference_node", "external_asset"],
+				"properties": {
+                    "reference_node": {
                         "type": "string",
                         "description": "Name of the parent node in the 3D model file."
                     },
-                    {
+                    "external_asset": {
                         "type": "string",
                         "description": "File path to the ASAM OpenMATERIAL 3D external ASAM OpenMATERIAL 3D asset files (.xoma).",
-                        "pattern": "^(\\./|/)?([a-zA-Z0-9_\\-./]+)\\.(xoma)$"
+						"pattern": "^(\\./|/)?([a-zA-Z0-9_\\-./]+)\\.(xoma)$"
                     }
-                ],
-                "minItems": 2,
-                "maxItems": 2
+				}
             }
         },
         "lightDefinitions": {

--- a/schemas/asset_schema.json
+++ b/schemas/asset_schema.json
@@ -342,6 +342,26 @@
                 "maxItems": 2
             }
         },
+        "externalAssetReferences": {
+            "type": "array",
+            "description": "Optional array containing references to external 3D assets. It links parenting nodes in the 3D model file to external ASAM OpenMATERIAL 3D asset files (.xoma).",
+            "items": {
+                "type": "array",
+                "items": [
+                    {
+                        "type": "string",
+                        "description": "Name of the parent node in the 3D model file."
+                    },
+                    {
+                        "type": "string",
+                        "description": "File path to the ASAM OpenMATERIAL 3D external ASAM OpenMATERIAL 3D asset files (.xoma).",
+                        "pattern": "^(\\./|/)?([a-zA-Z0-9_\\-./]+)\\.(xoma)$"
+                    }
+                ],
+                "minItems": 2,
+                "maxItems": 2
+            }
+        },
         "lightDefinitions": {
             "type": "array",
             "description": "A list of discrete light sources linked to the 3D asset hierarchy.",


### PR DESCRIPTION
## Describe your changes

Added an (optional) array of key-value pairs of parent nodes in a 3D model and references to external OpenMATERIAL 3D asset files to the schema and the documentation.

## Issue ticket number and link

#118 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code/documentation.
- [ ] My changes generate no new warnings during the documentation generation.